### PR TITLE
Fix query parameter usage in search

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "launch": "npx vite "
+  }
+}

--- a/index.html
+++ b/index.html
@@ -569,7 +569,7 @@
           const prompt = urlParams.get("prompt");
 
           newUrl.searchParams.set(
-            "query",
+            "q",
             prompt ? `${prompt}\n\n${this.value}` : this.value
           );
           if (!newUrl.searchParams.has("model")) {
@@ -582,7 +582,7 @@
         } else {
           // If textarea is empty, remove query parameter
           const newUrl = new URL(window.location.href);
-          newUrl.searchParams.delete("query");
+          newUrl.searchParams.delete("q");
           history.replaceState({}, "", newUrl.toString());
         }
       });
@@ -596,7 +596,7 @@
 
         // Clear URL parameter
         const newUrl = new URL(window.location.href);
-        newUrl.searchParams.delete("query");
+        newUrl.searchParams.delete("q");
         history.replaceState({}, "", newUrl.toString());
 
         // Clear iframes
@@ -631,7 +631,7 @@
           const prompt = urlParams.get("prompt");
 
           newUrl.searchParams.set(
-            "query",
+            "q",
             prompt ? `${prompt}\n\n${selection}` : selection
           );
           if (!newUrl.searchParams.has("model")) {


### PR DESCRIPTION
Remove the `query` parameter and replace it with the `q` parameter in the URL construction for search functionality.

* **Update URL construction:**
  - Replace `query` with `q` in the `performSearch` function.
  - Remove `query` parameter and replace it with `q` when the textarea is empty.
  - Clear the `q` parameter from the URL when the textarea is focused.

* **Add devcontainer configuration:**
  - Add `.devcontainer/devcontainer.json` file with launch task for `npx vite`.

